### PR TITLE
Allow to evalute py expressions inside variable expansions

### DIFF
--- a/cacts/cacts.py
+++ b/cacts/cacts.py
@@ -571,8 +571,9 @@ class Driver(object):
                 if name=='default':
                     continue
                 build = BuildType(name,self._project,self._machine,configs)
+
                 # Skip non-baselines builds when generating baselines
-                if not self._generate or build.uses_baselines:
+                if (not self._generate or build.uses_baselines) and build.on_by_default:
                     self._builds.append(build)
 
 ###############################################################################

--- a/cacts/cacts.py
+++ b/cacts/cacts.py
@@ -161,6 +161,8 @@ class Driver(object):
             print(f"Generating baselines from git ref '{git_ref}' (sha={git_sha})")
         else:
             print(f"Running tests for git ref '{git_ref}' (sha={git_sha}) on machine {self._machine.name}")
+
+        print(f"  active builds: {', '.join(b.name for b in self._builds)}")
         print("###############################################################################")
 
         success = True

--- a/cacts/machine.py
+++ b/cacts/machine.py
@@ -69,12 +69,12 @@ class Machine(object):
                 f"machine->env_setup should be a list of strings (got {type(self.env_setup)} instead).\n")
 
         try:
-            self.num_bld_res = int(props.get('num_bld_res',None) or get_available_cpu_count())
+            self.num_bld_res = int(props.get('num_bld_res',None))
         except ValueError as e:
             print(f"Cannot convert 'num_bld_res' entry to an integer. Please, fix the config file.\n")
             raise
         try:
-            self.num_run_res = int(props.get('num_run_res',None) or get_available_cpu_count())
+            self.num_run_res = int(props.get('num_run_res',None))
         except ValueError as e:
             print(f"Cannot convert 'num_run_res' entry to an integer. Please, fix the config file.\n")
             raise

--- a/cacts/utils.py
+++ b/cacts/utils.py
@@ -324,6 +324,17 @@ def evaluate_commands(tgt_obj):
     return tgt_obj
 
 ###############################################################################
+def str_to_bool(s, var_name):
+###############################################################################
+    if s=="True":
+        return True
+    elif s=="False":
+        return False
+    else:
+        raise ValueError(f"Invalid value '{s}' for '{var_name}'.\n"
+                          "Should be either 'True' or 'False'")
+
+###############################################################################
 def is_git_repo(repo=None):
 ###############################################################################
     """

--- a/cacts/utils.py
+++ b/cacts/utils.py
@@ -238,30 +238,57 @@ def expand_variables(tgt_obj, src_obj_dict):
             tgt_obj[i] = expand_variables(val,src_obj_dict)
 
     elif isinstance(tgt_obj,str):
-        pattern = r'\$\{(\w+)\.(\w+)\}'
+        pattern = r'\$\{(\w+)\.(\w+)(.*?)\}'
 
         matches = re.findall(pattern,tgt_obj)
-        for obj_name, att_name in matches:
+        for obj_name, att_name, expression in matches:
             expect (obj_name in src_obj_dict.keys(),
                     f"Invalid configuration ${{{obj_name}.{att_name}}}. Must be ${{obj.attr}}, with obj in {src_obj_dict.keys()}")
             obj = src_obj_dict[obj_name]
+            expect (hasattr(obj,att_name),
+                    f"{obj_name} has no attribute '{att_name}'\n"
+                    f"  - existing attributes: {dir(obj)}\n")
 
+            eval_str = f"obj.{att_name}{expression}"
+            expect (safe_expression(expression),
+                    f"Cannot evaluate expression '{obj_name}.{att_name}{expression}'. A dangerous pattern was detected in the expression")
             try:
-                value = getattr(obj,att_name)
-                expect (not value is None,
-                        f"Cannot use attribute {obj_name}.{att_name} in configuration, since it is None.\n")
-                value_str = str(value)
-                old = tgt_obj
-                tgt_obj = tgt_obj.replace(f"${{{obj_name}.{att_name}}}",value_str)
+                result = eval(eval_str)
+                tgt_obj = tgt_obj.replace(f"${{{obj_name}.{att_name}{expression}}}",str(result))
             except AttributeError:
-                print (f"{obj_name} has no attribute '{att_name}'\n")
-                print (f"  - existing attributes: {dir(obj)}\n")
+                print (f"Could not evaluate expression {tgt_obj}.\n")
                 raise
 
         expect (not re.findall(pattern,tgt_obj),
                 f"Something went wrong while replacing ${{..}} patterns in string '{tgt_obj}'\n")
 
     return tgt_obj
+
+#########################################################
+def safe_expression(expression):
+#########################################################
+
+    # List of dangerous patterns
+    dangerous_patterns = [
+        r'\bimport\b',           # Import statements
+        r'\bexec\b',             # Exec statements
+        r'\beval\b',             # Eval statements
+        r'\bos\.system\b',       # OS system calls
+        r'\bsubprocess\.run\b',  # Subprocess calls
+        r'\bglobals\b',          # Globals access
+        r'\blocals\b',           # Locals access
+        r';',                    # Multiple statements
+        r'\bopen\b',             # File access
+        r'\bos\.getenv\b',       # Environment variable access
+        r'\b__\w+__\b'           # Catch all for any double underscore attributes
+    ]
+
+    # Check for any dangerous patterns
+    for pattern in dangerous_patterns:
+        if re.search(pattern, expression):
+            return False  # Unsafe expression
+    
+    return True  # Safe expression
 
 ###############################################################################
 def evaluate_commands(tgt_obj):


### PR DESCRIPTION
This allows to add stuff like this to the yaml config file

```yaml
configurations:
  fpe:
    on_by_default: "${machine.gpu_arch is not None}"
```
which will evaluate `machine.gpu_arg` and then compare against `None`. The infrastructure allows for any complex py snippet, but it does put some safeguards, to prevent malicious code from executing. In particular, it prohibits these patterns:

```py
    # List of dangerous patterns
    dangerous_patterns = [
        r'\bimport\b',           # Import statements
        r'\bexec\b',             # Exec statements
        r'\beval\b',             # Eval statements
        r'\bos\.system\b',       # OS system calls
        r'\bsubprocess\.run\b',  # Subprocess calls
        r'\bglobals\b',          # Globals access
        r'\blocals\b',           # Locals access
        r';',                    # Multiple statements
        r'\bopen\b',             # File access
        r'\bos\.getenv\b',       # Environment variable access
        r'\b__\w+__\b'           # Catch all for any double underscore attributes
    ]
```
