### PR TITLE
Allow inheritance between builds/machines

### DIFF
--- a/cacts/build_type.py
+++ b/cacts/build_type.py
@@ -18,11 +18,24 @@ class BuildType(object):
                 f"BuildType '{name}' not found in the 'build_types' section of the config file.\n"
                 f" - available build types: {','.join(b for b in builds_specs.keys() if b!='default')}\n")
 
+        self.name = name
+
+        # Init everything to None
+        self.longname       = None
+        self.description    = None
+        self.uses_baselines = None
+        self.on_by_default  = None
+        self.cmake_args     = None
+        self.inherits       = None
+
+        # Set parameter, first using the 'default' build (if any), then this build's settings
+        # Note: if this build inherits from B2, B2's settings will be parsed first
+        self.update_params(builds_specs,'default')
+        self.update_params(builds_specs,name)
+
         # Get props for this build type and for a default build
         props   = builds_specs[name]
         default = builds_specs.get('default',{})
-
-        # Set build props
         self.name   = name
         self.longname    = props.get('longname',name)
         self.description = props.get('description',None)
@@ -67,3 +80,10 @@ class BuildType(object):
         self.compile_res_count = None
         self.testing_res_count = None
         self.baselines_missing = False
+
+    def update_params(self,builds_specs,name):
+        if name in builds_specs.keys():
+            props = builds_specs[name]
+            if 'inherits' in props.keys():
+                self.update_params(builds_specs,props['inherits'])
+            self.__dict__.update(props)

--- a/cacts/machine.py
+++ b/cacts/machine.py
@@ -34,24 +34,35 @@ class Machine(object):
                     f"Machine '{name}' not found in the 'machines' section of the config file.\n"
                     f" - available machines: {','.join(m for m in machines_specs.keys() if m!='default')}\n")
 
-        # Get props for this machine and for a default machine
-        props   = machines_specs[name]
-        default = machines_specs.get('default',{})
-
-        # Set mach props
         self.name = name
-        self.mach_file = props.get('mach_file',None) or default.get('mach_file',None)
-        self.num_bld_res = props.get('num_bld_res',None) or default.get('num_bld_res',None) or get_available_cpu_count()
-        self.num_run_res = props.get('num_run_res',None) or default.get('num_run_res',None) or get_available_cpu_count()
-        self.env_setup = props.get("env_setup",[])
-        self.gpu_arch = props.get("gpu_arch",None)
-        self.batch = props.get("batch",None)
-        self.cxx_compiler = props.get("cxx_compiler",None) or default.get("cxx_compiler",None)
-        self.c_compiler   = props.get("c_compiler",None) or default.get("c_compiler",None)
-        self.ftn_compiler = props.get("ftn_compiler",None) or default.get("ftn_compiler",None)
-        self.baselines_dir = props.get("baselines_dir",None)
-        self.valg_supp_file = props.get("valg_supp_file",None)
 
+        # Init everything to None
+        self.mach_file      = None
+        self.num_bld_res    = None
+        self.num_run_res    = None
+        self.env_setup      = None
+        self.gpu_arch       = None
+        self.batch          = None
+        self.cxx_compiler   = None
+        self.c_compiler     = None
+        self.ftn_compiler   = None
+        self.baselines_dir  = None
+        self.valg_supp_file = None
+        self.inherits       = None
+
+        # Set parameter, first using the 'default' machine (if any), then this machine's settings
+        # Note: if this machine inherits from M2, M2's settings will be parsed first
+        self.update_params(machines_specs,'default')
+        self.update_params(machines_specs,name)
+
+        # If these are still None, set some defaults
+        # NOTE: DON'T do this before all dicts update calls, since a value of None in one
+        # of the dicts would end up overwriting the default. So do this AFTER all updates
+        self.env_setup = self.env_setup or []
+        self.num_bld_res = self.num_bld_res or get_available_cpu_count()
+        self.num_run_res = self.num_run_res or get_available_cpu_count()
+
+        # Expand variables and evaluate expressions
         # Perform substitution of ${..} strings
         objects = {
             'project' : project,
@@ -69,15 +80,22 @@ class Machine(object):
                 f"machine->env_setup should be a list of strings (got {type(self.env_setup)} instead).\n")
 
         try:
-            self.num_bld_res = int(props.get('num_bld_res',None))
+            self.num_bld_res = int(self.num_bld_res)
         except ValueError as e:
             print(f"Cannot convert 'num_bld_res' entry to an integer. Please, fix the config file.\n")
             raise
         try:
-            self.num_run_res = int(props.get('num_run_res',None))
+            self.num_run_res = int(self.num_run_res)
         except ValueError as e:
             print(f"Cannot convert 'num_run_res' entry to an integer. Please, fix the config file.\n")
             raise
+
+    def update_params(self,machines_specs,name):
+        if name in machines_specs.keys():
+            props = machines_specs[name]
+            if 'inherits' in props.keys():
+                self.update_params(machines_specs,props['inherits'])
+            self.__dict__.update(props)
 
     def uses_gpu (self):
         return self.gpu_arch is not None


### PR DESCRIPTION
Allows to set common properties in intermediate builds/machines. See linked issue for an example.

Closes #7 