### PR TITLE
Refactor how cacts builds the project

### DIFF
--- a/cacts/build_type.py
+++ b/cacts/build_type.py
@@ -48,13 +48,13 @@ class BuildType(object):
 
         expect (isinstance(props.get('cmake_args',{}),dict),
                 f"Invalid value for cmake_args for build type '{name}'.\n"
-                f"  - input value: {props['cmake_args']}\n"
-                f"  - input type: {type(props['cmake_args'])}\n"
+                f"  - input value: {props.get('cmake_args',{})}\n"
+                f"  - input type: {type(props.get('cmake_args',{}))}\n"
                  "  - expected type: dict\n")
         expect (isinstance(default.get('cmake_args',{}),dict),
                 f"Invalid value for cmake_args for build type 'default'.\n"
-                f"  - input value: {default['cmake_args']}\n"
-                f"  - input type: {type(default['cmake_args'])}\n"
+                f"  - input value: {default.get('cmake_args',{})}\n"
+                f"  - input type: {type(default.get('cmake_args',{}))}\n"
                  "  - expected type: dict\n")
         self.cmake_args = default.get('cmake_args',{})
         self.cmake_args.update(props.get('cmake_args',{}))

--- a/cacts/build_type.py
+++ b/cacts/build_type.py
@@ -68,7 +68,7 @@ class BuildType(object):
         expand_variables(self,objects)
 
         # Evaluate remaining bash commands of the form $(...)
-        evaluate_commands(self)
+        evaluate_commands(self," && ".join(machine.env_setup))
 
         # After vars expansion, these two must be convertible to bool
         if type(self.uses_baselines) is str:

--- a/cacts/build_type.py
+++ b/cacts/build_type.py
@@ -41,6 +41,7 @@ class BuildType(object):
         self.description = props.get('description',None)
         self.uses_baselines = props.get('uses_baselines',None)
         self.on_by_default  = props.get('on_by_default',None)
+        self.coverage = props.get('coverage',False)
         if  self.uses_baselines is None:
             self.uses_baselines = default.get('uses_baselines',True)
         if  self.on_by_default is None:

--- a/cacts/cacts.py
+++ b/cacts/cacts.py
@@ -424,10 +424,10 @@ class Driver(object):
         if self._submit:
             cdash = self._project.cdash
             text += '# Submission specs\n'
-            text += f'set(CTEST_BUILD_NAME {self._project.cdash.get('build_prefix','')+build.longname})\n'
+            text += f'set(CTEST_BUILD_NAME {self._project.cdash.get("build_prefix","")+build.longname})\n'
             text += f'set(CTEST_SITE {self._machine.name})\n'
-            text += f'set(CTEST_DROP_SITE {cdash['drop_site']})\n'
-            text += f'set(CTEST_DROP_LOCATION {cdash['drop_location']})\n'
+            text += f'set(CTEST_DROP_SITE {cdash["drop_site"]})\n'
+            text += f'set(CTEST_DROP_LOCATION {cdash["drop_location"]})\n'
             disable_ssl = cdash.get('curl_ssl_off',False)
             if disable_ssl:
                 curl_options = 'CURLOPT_SSL_VERIFYPEER_OFF;CURLOPT_SSL_VERIFYHOST_OFF'

--- a/cacts/cacts.py
+++ b/cacts/cacts.py
@@ -211,7 +211,6 @@ class Driver(object):
     ###############################################################################
 
         build_dir = self._work_dir / build.longname
-
         if self._skip_config:
             expect (build_dir.exists(),
                     "Build directory did not exist, but --skip-config/--skip-build was used.\n")
@@ -219,6 +218,12 @@ class Driver(object):
             if build_dir.exists():
                 shutil.rmtree(build_dir)
             build_dir.mkdir()
+
+        baseline_dir = self._baselines_dir / build.longname
+        baseline_data_dir = baseline_dir / "data"
+        if self._generate:
+            baseline_dir.mkdir(exist_ok=True)
+            baseline_data_dir.mkdir(exist_ok=True)
 
         self.create_ctest_resource_file(build,build_dir)
         cmake_config = self.generate_cmake_config(build)
@@ -238,7 +243,6 @@ class Driver(object):
         success = stat==0
 
         if self._generate and success:
-            baseline_dir = self._baselines_dir / build.longname
 
             # Read list of nc files to copy to baseline dir
             if self._project.baselines_summary_file is not None:

--- a/cacts/cacts.py
+++ b/cacts/cacts.py
@@ -105,7 +105,7 @@ class Driver(object):
         ###################################
 
         if self._baselines_dir:
-            if self._baselines_dir == "AUTO":
+            if self._baselines_dir.casefold() == "AUTO".casefold():
                 self._baselines_dir = pathlib.Path(self._machine.baselines_dir).expanduser().absolute()
             else:
                 self._baselines_dir = pathlib.Path(self._baselines_dir).expanduser().absolute()

--- a/cacts/cacts.py
+++ b/cacts/cacts.py
@@ -183,6 +183,7 @@ class Driver(object):
 
         success = True
         for b,s in builds_success.items():
+            success &= s
             if not s:
                 last_submit = self.get_last_ctest_file(b,"Submit")
                 last_test = self.get_last_ctest_file(b,"TestsFailed")
@@ -233,7 +234,8 @@ class Driver(object):
 
         # Run ctest
         env_setup = " && ".join(self._machine.env_setup)
-        success,_,_ = run_cmd(ctest_cmd,arg_stdout=None,arg_stderr=None,env_setup=env_setup,from_dir=build_dir,verbose=True)
+        stat, _, _ = run_cmd(ctest_cmd,arg_stdout=None,arg_stderr=None,env_setup=env_setup,from_dir=build_dir,verbose=True)
+        success = stat==0
 
         if self._generate and success:
             baseline_dir = self._baselines_dir / build.longname

--- a/cacts/cacts.py
+++ b/cacts/cacts.py
@@ -586,9 +586,9 @@ OR
             help="Extra custom options to pass to cmake. Can use multiple times for multiple cmake options. "
                  "The -D is added for you, so just do VAR=VALUE. These value will supersed any other setting "
                  "(including machine/build specs)")
-    parser.add_argument("-R", "--test-regex",
+    parser.add_argument("--test-regex",
                         help="Limit ctest to running only tests that match this regex")
-    parser.add_argument("-L", "--test-labels", nargs='+', default=[],
+    parser.add_argument("--test-labels", nargs='+', default=[],
                         help="Limit ctest to running only tests that match this label")
 
 

--- a/cacts/cacts.py
+++ b/cacts/cacts.py
@@ -190,19 +190,19 @@ class Driver(object):
                 last_build  = self.get_last_ctest_file(b,"Build")
                 last_config = self.get_last_ctest_file(b,"Configure")
                 if last_submit is not None:
-                    print(f"Build type {b} failed at submit time. Here's the content of {last_submit}:")
+                    print(f"Build type {b.longname} failed at submit time. Here's the content of {last_submit}:")
                     print (last_submit.read_text())
                 if last_test is not None:
-                    print(f"Build type {b} failed at testing time. Here's the content of {last_test}:")
+                    print(f"Build type {b.longname} failed at testing time. Here's the content of {last_test}:")
                     print (last_test.read_text())
                 elif last_build is not None:
-                    print(f"Build type {b} failed at build time. Here's the content of {last_build}:")
+                    print(f"Build type {b.longname} failed at build time. Here's the content of {last_build}:")
                     print (last_build.read_text())
                 elif last_config is not None:
-                    print(f"Build type {b} failed at config time. Here's the content of {last_config}:")
+                    print(f"Build type {b.longname} failed at config time. Here's the content of {last_config}:")
                     print (last_config.read_text())
                 else:
-                    print(f"Build type {t} failed before configure step.")
+                    print(f"Build type {b.longname} failed before configure step.")
 
         return success
 

--- a/cacts/machine.py
+++ b/cacts/machine.py
@@ -20,7 +20,7 @@ class Machine:
         # Check inputs
         expect (isinstance(machines_specs,dict),
                 "Machine constructor expects a dict object for 'machines_specs'"
-                "  - type(machine_specs): {type(machines_specs)}.\n")
+                "  - type(machines_specs): {type(machines_specs)}.\n")
         if name is None:
             hostname = socket.gethostname()
             # Loop over machines, and see if there's one whose 'node_regex' matches the hostname
@@ -37,7 +37,7 @@ class Machine:
                     "Machine name was not provided, and none of the machines' node_regex "
                     f"matches hostname={hostname}\n")
         else:
-            avail_machs = machine_specs.keys()
+            avail_machs = machines_specs.keys()
             expect (name in avail_machs,
                     f"Machine '{name}' not found in the 'machines' section of the config file.\n"
                     f" - available machines: {','.join(m for m in avail_machs if m!='default')}\n")

--- a/cacts/project.py
+++ b/cacts/project.py
@@ -34,8 +34,9 @@ class Project(object):
         # Can help to limit build time
         # NOTE: projects may have an option to ENABLE such code or an optio to DISABLE it.
         # Hence, we ooffer both alternatives
-        self.enable_baselines_cmake_var  = project_specs.get('enable_baselines_code',None)
-        self.disable_baselines_cmake_var = project_specs.get('disable_baselines_code',None)
+        self.cmake_vars_names = project_specs.get('cmake_vars_names',{})
+
+        self.cdash = project_specs.get('cdash',{})
 
         # Evaluate remaining bash commands of the form $(...)
         evaluate_commands(self)

--- a/cacts/utils.py
+++ b/cacts/utils.py
@@ -291,28 +291,28 @@ def safe_expression(expression):
     return True  # Safe expression
 
 ###############################################################################
-def evaluate_commands(tgt_obj):
+def evaluate_commands(tgt_obj,env_setup=None):
 ###############################################################################
 
     # Only user-defined types have the __dict__ attribute
     if hasattr(tgt_obj,'__dict__'):
         for name,val in vars(tgt_obj).items():
-            setattr(tgt_obj,name,evaluate_commands(val))
+            setattr(tgt_obj,name,evaluate_commands(val,env_setup))
 
     elif isinstance(tgt_obj,dict):
         for name,val in tgt_obj.items():
-            tgt_obj[name] = evaluate_commands(val)
+            tgt_obj[name] = evaluate_commands(val,env_setup)
 
     elif isinstance(tgt_obj,list):
         for i,val in enumerate(tgt_obj):
-            tgt_obj[i] = evaluate_commands(val)
+            tgt_obj[i] = evaluate_commands(val,env_setup)
 
     elif isinstance(tgt_obj,str):
         pattern = r'\$\((.*?)\)'
 
         matches = re.findall(pattern,tgt_obj)
         for cmd in matches:
-            stat,out,err = run_cmd(cmd)
+            stat,out,err = run_cmd(cmd,env_setup=env_setup)
             expect (stat==0,
                     "Could not evaluate the command.\n"
                     f"  - original string: {tgt_obj}\n"

--- a/examples/eamxx.yaml
+++ b/examples/eamxx.yaml
@@ -37,10 +37,10 @@ project:
     baseline_summary_file: baseline_list
     enable_baselines_cmake_option: SCREAM_ENABLE_BASELINE_TESTS
     cdash:
-      project: SCREAM # In case CDash project name differs. Defaults to project.name
-      url: https://my.cdash.org/submit.php?project=E3SM
-      build_prefix: scream_unit_tests_  # Optional. Final value of --build is this plus ${machine.name}
-      track: E3SM_SCREAM  # Optional
+      drop_site: my.cdash.org
+      drop_location: submit.php?project=E3SM
+      build_prefix: scream_unit_tests_  # Optional. Final value of is this plus ${build.name}
+      curl_disable_ssl: True
     # CACTS will also set project.root_dir at runtime, so you can actually use
     # ${project.root_dir} in the machines/configurations sections
 


### PR DESCRIPTION
I originally split the build into cmake + make + ctest + ctest-submit. But this had a big problem: ctest would not find any xml file for config/build/test to submit.

This PR does a few things:

- just run ctest (one single command) to do all: config, build, test, coverage (if any), submit (if requested)
- revert impl of run_cmd to what we have in eamxx (plus one small mod): I had a different impl, since I wanted to redirect output to a log file, so we could print errors. But ctest already generates the log files, so this is no longer needed
- add coverage (default False) to build type: it was hard to request coverage just from existing cmake_args props. We would have had to handle cmake vars inside the ctest script...speaking of which...
- automatically generate ctest_script.cmake in the bld directory: no need for the project to craft one. We create it based on cacts cmd line args (e.g., if --config-only, we only create the script up to ctest_configure).
- fix cdash submission configuration from yaml file: we require a few params, and do away with requiring the project to have a CTestConfig.cmake script. 
- merge `generate_baselines` and `run_build` into one. They only differ in what to do after `run_cmd` returns: for testing, nothing to do, for generating, copy baselines to baseline dir (if successful).
- fix pylint complains for project.py: convert class to a "dataclass"

Fixes #14