### PR TITLE
Add get-mach-env utility executable

### DIFF
--- a/cacts/__init__.py
+++ b/cacts/__init__.py
@@ -1,8 +1,12 @@
 """ Main entry point for cacts"""
 
 from cacts.cacts import main as cacts_main
+from cacts.get_mach_env import print_mach_env
 
 __version__ = "0.1.0"
 
 def main() -> None:
     cacts_main()
+
+def get_mach_env() -> None:
+    print_mach_env()

--- a/cacts/get_mach_env.py
+++ b/cacts/get_mach_env.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import pathlib
+import argparse
+
+from .parse_config  import parse_project, parse_machine
+from .utils         import check_minimum_python_version, GoodFormatter
+
+check_minimum_python_version(3, 4)
+
+###############################################################################
+def print_mach_env():
+###############################################################################
+    from . import __version__  # Import __version__ here to avoid circular import
+
+    args = vars(parse_command_line(sys.argv, __doc__, __version__))
+
+    project = parse_project(args['config_file'],args['root_dir'])
+    machine = parse_machine(args['config_file'],project,args['machine_name'])
+
+    print(" && ".join(machine.env_setup))
+
+    sys.exit(0)
+
+###############################################################################
+def parse_command_line(args, description, version):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        usage="""\n{0} <ARGS> [--verbose]
+OR
+{0} --help
+
+\033[1mEXAMPLES:\033[0m
+    \033[1;32m# Get the env setup command for machine 'foo' using config file my_config.yaml \033[0m
+    > ./{0} foo -f my_config.yaml
+""".format(pathlib.Path(args[0]).name),
+        description=description,
+        formatter_class=GoodFormatter
+    )
+
+    parser.add_argument("-f","--config-file", default=f"{os.getcwd()}/cacts.yaml",
+        help="YAML file containing valid project/machine settings")
+
+    parser.add_argument("-r", "--root-dir", default=f"{os.getcwd()}",
+        help="The root directory of the project, where the main CMakeLists.txt file is located")
+
+    parser.add_argument("machine_name", help="The machine name for which you want the scream env")
+
+    return parser.parse_args(args[1:])

--- a/cacts/parse_config.py
+++ b/cacts/parse_config.py
@@ -1,0 +1,72 @@
+import pathlib
+import yaml
+
+from .project    import Project
+from .machine    import Machine
+from .build_type import BuildType
+from .utils      import expect, check_minimum_python_version
+
+check_minimum_python_version(3, 4)
+
+###############################################################################
+def parse_project(config_file,root_dir):
+###############################################################################
+    content = yaml.load(open(config_file,"r"),Loader=yaml.SafeLoader)
+
+    expect ('project' in content.keys(),
+            "Missing 'project' section in configuration file\n"
+            f" - config file: {config_file}\n"
+            f" - sections found: {','.join(content.keys())}\n")
+
+    # Build Project
+    return Project(content['project'],root_dir)
+
+###############################################################################
+def parse_machine(config_file,project,machine_name):
+###############################################################################
+    content = yaml.load(open(config_file,"r"),Loader=yaml.SafeLoader)
+
+    expect ('machines' in content.keys(),
+            "Missing 'machines' section in configuration file\n"
+            f" - config file: {config_file}\n"
+            f" - sections found: {','.join(content.keys())}\n")
+
+    # Special handling of 'local' machine
+    machs = content['machines']
+    if machine_name=="local":
+        local_yaml = pathlib.Path("~/.cime/cacts.yaml").expanduser()
+        local_content = yaml.load(open(local_yaml,'r'),Loader=yaml.SafeLoader)
+        machs.update(local_content['machines'])
+        machine_name = 'local'
+
+    # Build Machine
+    return Machine(machine_name,project,machs)
+
+###############################################################################
+def parse_builds(config_file,project,machine,generate,build_types=None):
+###############################################################################
+    content = yaml.load(open(config_file,"r"),Loader=yaml.SafeLoader)
+
+    expect ('configurations' in content.keys(),
+            "Missing 'configurations' section in configuration file\n"
+            f" - config file: {config_file}\n"
+            f" - sections found: {','.join(content.keys())}\n")
+
+    # Get builds
+    builds = []
+    if build_types:
+        for name in build_types:
+            build = BuildType(name,project,machine,content['configurations'])
+            # Skip non-baselines builds when generating baselines
+            if not generate or build.uses_baselines:
+                builds.append(build)
+    else:
+        # Add all build types that are on by default
+        for name in configs.keys():
+            if name=='default':
+                continue
+            build = BuildType(name,project,machine,content['configurations'])
+
+            # Skip non-baselines builds when generating baselines
+            if (not generate or build.uses_baselines) and build.on_by_default:
+                builds.append(build)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
 
 [project.scripts]
 cacts = "cacts:main"
+get-mach-env = "cacts:get_mach_env"
 
 [tool.hatch.version]
 path = "cacts/__init__.py"


### PR DESCRIPTION
This PR

- extracts the yaml file parsing into its own module
- uses the parsing module to provide a utility that prints the machine env setup cmd to screen

Closes #3 