### PR TITLE
Offer a better granularity when it comes to cmake options

### DIFF
--- a/cacts/cacts.py
+++ b/cacts/cacts.py
@@ -364,34 +364,23 @@ class Driver(object):
         if self._machine.ftn_compiler is not None:
             cmake_config += f" -DCMAKE_Fortran_COMPILER={self._machine.ftn_compiler}"
 
-        proj_cmake_vars = self._project.cmake_vars_names;
+        proj_cmake_settings = self._project.cmake_settings;
         if self._enable_baselines_tests:
-            if 'enable_baselines' in proj_cmake_vars.keys():
-                # The project has cmake vars to set in order to ENABLE baseline tests
-                # Set these vars to the specified values
-                options = proj_cmake_vars['enable_baselines']
-                for var_name,var_value in options.items():
-                    cmake_config += f" -D{var_name}={var_value}"
-
-            if self._generate and 'generate_baselines' in proj_cmake_vars.keys():
-                # The project has cmake vars to set in order to GENERATE baseline
-                # Set these vars to the specified values
-                # NOTE: this option may enable only a SUBSET of baseline tests,
-                #       and help reduce the build/run time when generating
-                options = proj_cmake_vars['generate_baselines']
-                for var_name,var_value in options.items():
-                    cmake_config += f" -D{var_name}={var_value}"
-
-            if 'baselines_dir' in proj_cmake_vars.keys():
-                # The project has a cmake var to be set to specify baselines location
-                var_name = proj_cmake_vars['baselines_dir']
-                var_value = self._baselines_dir / build.longname
+            # If the project has cmake vars to set in order to ENABLE baseline tests,
+            # set these vars to the specified values
+            for var_name,var_value in proj_cmake_settings['baselines_on'].items():
                 cmake_config += f" -D{var_name}={var_value}"
-        elif 'disable_baselines' in proj_cmake_vars.keys():
-            # The project has cmake vars to set in order to DISABLE baseline tests
-            # Set these vars to the specified values
-            options = proj_cmake_vars['disable_baselines']
-            for var_name,var_value in options.items():
+
+            # If the project has cmake vars to set in order to GENERATE baselines,
+            # set these vars to the specified values
+            # NOTE: this option may enable only a SUBSET of baseline tests,
+            #       and help reduce the build/run time when generating
+            for var_name,var_value in proj_cmake_settings['baselines_only'].items():
+                cmake_config += f" -D{var_name}={var_value}"
+        else:
+            # If the project has cmake vars to set in order to DISABLE baseline tests,
+            # set these vars to the specified values
+            for var_name,var_value in proj_cmake_settings['baselines_off'].items():
                 cmake_config += f" -D{var_name}={var_value}"
 
         # User-requested config options

--- a/cacts/project.py
+++ b/cacts/project.py
@@ -27,7 +27,7 @@ class Project:
             'baseline_gen_label',
             'baseline_cmp_label',
             'baseline_summary_file',
-            'cmake_vars_names',
+            'cmake_settings',
             'cdash'
     }
 
@@ -64,7 +64,12 @@ class Project:
         # Can help to limit build time
         # NOTE: projects may have an option to ENABLE such code or an optio to DISABLE it.
         # Hence, we ooffer both alternatives
-        self.cmake_vars_names = project_specs.get('cmake_vars_names',{})
+        self.cmake_settings = project_specs.get('cmake_settings',{})
+
+        # Set empty sub-dicts if not present
+        self.cmake_settings.setdefault('baselines_on',{})
+        self.cmake_settings.setdefault('baselines_off',{})
+        self.cmake_settings.setdefault('baselines_only',{})
 
         self.cdash = project_specs.get('cdash',{})
 

--- a/examples/eamxx.yaml
+++ b/examples/eamxx.yaml
@@ -35,12 +35,18 @@ project:
     name: EAMxx
     baseline_gen_label: baseline_gen
     baseline_summary_file: baseline_list
-    cmake_vars_names:
-      enable_baselines:
-          SCREAM_ENABLE_BASELINE_TESTS: ON
-      generate_baselines: 
-          SCREAM_ONLY_GENERATE_BASELINES: ON
-      baselines_dir: SCREAM_BASELINES_DIR
+    cmake_settings:
+        # The following settings are OPTIONAL, but can help reduce the amount of stuff that
+        # needs to be built/run, depending on whether -g/-b flags are used
+        baselines_on:
+            # These settings are used when -b <DIR> flag is passed
+            SCREAM_ENABLE_BASELINE_TESTS: ON
+        baselines_off:
+            # These settings are used when -b <DIR> flag is NOT passed
+            SCREAM_ENABLE_BASELINE_TESTS: OFF
+        baselines_only:
+            # These settings are used when -g flags is passed
+            SCREAM_ONLY_GENERATE_BASELINES: ON
     cdash:
         drop_site: my.cdash.org
         drop_location: submit.php?project=E3SM


### PR DESCRIPTION
Namely, the project may have logic to enable/disable baselines, as well as to ONLY enable baselines tests (useful in a generate run).