### PR TITLE
Fix and uprade expansion of variable to support any py expression

### DIFF
--- a/cacts/__init__.py
+++ b/cacts/__init__.py
@@ -3,7 +3,7 @@
 from cacts.cacts import main as cacts_main
 from cacts.get_mach_env import print_mach_env
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 def main() -> None:
     cacts_main()

--- a/cacts/build_type.py
+++ b/cacts/build_type.py
@@ -1,6 +1,6 @@
 import re
 
-from .utils import expect, expand_variables, evaluate_commands, str_to_bool
+from .utils import expect, evaluate_py_expressions, evaluate_bash_commands, str_to_bool
 
 ###############################################################################
 class BuildType(object):
@@ -66,10 +66,10 @@ class BuildType(object):
             'machine' : machine,
             'build'   : self
         }
-        expand_variables(self,objects)
+        evaluate_py_expressions(self,objects)
 
         # Evaluate remaining bash commands of the form $(...)
-        evaluate_commands(self," && ".join(machine.env_setup))
+        evaluate_bash_commands(self," && ".join(machine.env_setup))
 
         # After vars expansion, these two must be convertible to bool
         if type(self.uses_baselines) is str:

--- a/cacts/machine.py
+++ b/cacts/machine.py
@@ -7,7 +7,7 @@ import pathlib
 import socket
 import re
 
-from .utils import expect, get_available_cpu_count, expand_variables, evaluate_commands
+from .utils import expect, get_available_cpu_count, evaluate_py_expressions, evaluate_bash_commands
 
 ###############################################################################
 class Machine:
@@ -76,10 +76,10 @@ class Machine:
             'project' : project,
             'machine' : self,
         }
-        expand_variables(self,objects)
+        evaluate_py_expressions(self,objects)
 
         # Evaluate remaining bash commands of the form $(...)
-        evaluate_commands(self)
+        evaluate_bash_commands(self)
 
         # Check props are valid
         expect (self.mach_file is None or pathlib.Path(self.mach_file).expanduser().exists(),

--- a/cacts/project.py
+++ b/cacts/project.py
@@ -4,7 +4,7 @@ that CACTS will use at runtime
 """
 from dataclasses import dataclass, field
 from typing import Dict, Optional
-from .utils import expect, evaluate_commands
+from .utils import expect, evaluate_bash_commands
 
 ###############################################################################
 @dataclass
@@ -74,4 +74,4 @@ class Project:
 
     def __post_init__  (self):
         # Evaluate bash commands of the form $(...)
-        evaluate_commands(self)
+        evaluate_bash_commands(self)

--- a/cacts/project.py
+++ b/cacts/project.py
@@ -18,7 +18,6 @@ class Project:
     baselines_gen_label: Optional[str] = None
     baselines_cmp_label: Optional[str] = None
     baselines_summary_file: Optional[str] = None
-    cmake_vars_names: Dict[str, any] = field(default_factory=dict)
     cdash: Dict[str, any] = field(default_factory=dict)
 
     # To check inside init

--- a/cacts/utils.py
+++ b/cacts/utils.py
@@ -185,21 +185,21 @@ class SharedArea(object):
         os.umask(self._orig_umask)
 
 ###############################################################################
-def expand_variables(tgt_obj, src_obj_dict):
+def evaluate_py_expressions(tgt_obj, src_obj_dict):
 ###############################################################################
 
     # Only user-defined types have the __dict__ attribute
     if hasattr(tgt_obj,'__dict__'):
         for name,val in vars(tgt_obj).items():
-            setattr(tgt_obj,name,expand_variables(val,src_obj_dict))
+            setattr(tgt_obj,name,evaluate_py_expressions(val,src_obj_dict))
 
     elif isinstance(tgt_obj,dict):
         for name,val in tgt_obj.items():
-            tgt_obj[name] = expand_variables(val,src_obj_dict)
+            tgt_obj[name] = evaluate_py_expressions(val,src_obj_dict)
 
     elif isinstance(tgt_obj,list):
         for i,val in enumerate(tgt_obj):
-            tgt_obj[i] = expand_variables(val,src_obj_dict)
+            tgt_obj[i] = evaluate_py_expressions(val,src_obj_dict)
 
     elif isinstance(tgt_obj,str):
 
@@ -262,21 +262,21 @@ def safe_expression(expression):
     return True  # Safe expression
 
 ###############################################################################
-def evaluate_commands(tgt_obj,env_setup=None):
+def evaluate_bash_commands(tgt_obj,env_setup=None):
 ###############################################################################
 
     # Only user-defined types have the __dict__ attribute
     if hasattr(tgt_obj,'__dict__'):
         for name,val in vars(tgt_obj).items():
-            setattr(tgt_obj,name,evaluate_commands(val,env_setup))
+            setattr(tgt_obj,name,evaluate_bash_commands(val,env_setup))
 
     elif isinstance(tgt_obj,dict):
         for name,val in tgt_obj.items():
-            tgt_obj[name] = evaluate_commands(val,env_setup)
+            tgt_obj[name] = evaluate_bash_commands(val,env_setup)
 
     elif isinstance(tgt_obj,list):
         for i,val in enumerate(tgt_obj):
-            tgt_obj[i] = evaluate_commands(val,env_setup)
+            tgt_obj[i] = evaluate_bash_commands(val,env_setup)
 
     elif isinstance(tgt_obj,str):
         pattern = r'\$\((.*?)\)'

--- a/cacts/utils.py
+++ b/cacts/utils.py
@@ -202,29 +202,36 @@ def expand_variables(tgt_obj, src_obj_dict):
             tgt_obj[i] = expand_variables(val,src_obj_dict)
 
     elif isinstance(tgt_obj,str):
-        pattern = r'\$\{(\w+)\.(\w+)(.*?)\}'
 
-        matches = re.findall(pattern,tgt_obj)
-        for obj_name, att_name, expression in matches:
+        # First, extract content of ${...} (if any)
+        beg = tgt_obj.find("${")
+        end = tgt_obj.rfind("}")
+
+        if beg==-1:
+            expect (end==-1, f"Badly formatted expression '{tgt_obj}'.")
+            return tgt_obj
+
+        expect (end>beg, f"Badly formatted expression '{tgt_obj}'.")
+
+        expression = tgt_obj[beg+2:end]
+
+        pattern = r'\b(\w+)\.(\w+)\b'
+        matches = re.findall(pattern,expression)
+        for obj_name, att_name in matches:
             expect (obj_name in src_obj_dict.keys(),
-                    f"Invalid configuration ${{{obj_name}.{att_name}}}. Must be ${{obj.attr}}, with obj in {src_obj_dict.keys()}")
-            obj = src_obj_dict[obj_name]
-            expect (hasattr(obj,att_name),
-                    f"{obj_name} has no attribute '{att_name}'\n"
-                    f"  - existing attributes: {dir(obj)}\n")
+                    f"Invalid expression '{obj_name}.{att_name}': '{obj_name}' must be in {src_obj_dict.keys()}")
 
-            eval_str = f"obj.{att_name}{expression}"
-            expect (safe_expression(expression),
-                    f"Cannot evaluate expression '{obj_name}.{att_name}{expression}'. A dangerous pattern was detected in the expression")
-            try:
-                result = eval(eval_str)
-                tgt_obj = tgt_obj.replace(f"${{{obj_name}.{att_name}{expression}}}",str(result))
-            except AttributeError:
-                print (f"Could not evaluate expression {tgt_obj}.\n")
-                raise
+            expression = expression.replace(f'{obj_name}.{att_name}',f"src_obj_dict['{obj_name}'].{att_name}")
 
-        expect (not re.findall(pattern,tgt_obj),
-                f"Something went wrong while replacing ${{..}} patterns in string '{tgt_obj}'\n")
+        expect (safe_expression(expression),
+                f"Cannot evaluate expression '{tgt_obj}'. A dangerous pattern was detected in the expression")
+
+        try:
+            result = eval(expression)
+            tgt_obj = tgt_obj[:beg] + str(result) + tgt_obj[end+1:]
+        except AttributeError:
+            print (f"Could not evaluate expression {tgt_obj}.\n")
+            raise
 
     return tgt_obj
 


### PR DESCRIPTION
The need for this arose when I tried to do the following
```yaml
  EKAT_TEST_MAX_THREADS: ${machine.num_run_res if machine.gpu_arch is None else 1}
```
inside a cacts config file. This did not work with current main. This PR allows to evaluate an arbitrary py expression (provided it does not contain strings that are associated with security threats).

With this PR, I was able to use the above syntax in a cacts config file, and have it correctly resolved.