### PR TITLE
Remove evaluate_bash_commands utility

### DIFF
--- a/cacts/build_type.py
+++ b/cacts/build_type.py
@@ -1,6 +1,6 @@
 import re
 
-from .utils import expect, evaluate_py_expressions, evaluate_bash_commands, str_to_bool
+from .utils import expect, evaluate_py_expressions, str_to_bool
 
 ###############################################################################
 class BuildType(object):
@@ -67,9 +67,6 @@ class BuildType(object):
             'build'   : self
         }
         evaluate_py_expressions(self,objects)
-
-        # Evaluate remaining bash commands of the form $(...)
-        evaluate_bash_commands(self," && ".join(machine.env_setup))
 
         # After vars expansion, these two must be convertible to bool
         if type(self.uses_baselines) is str:

--- a/cacts/machine.py
+++ b/cacts/machine.py
@@ -7,7 +7,7 @@ import pathlib
 import socket
 import re
 
-from .utils import expect, get_available_cpu_count, evaluate_py_expressions, evaluate_bash_commands
+from .utils import expect, get_available_cpu_count, evaluate_py_expressions
 
 ###############################################################################
 class Machine:
@@ -77,9 +77,6 @@ class Machine:
             'machine' : self,
         }
         evaluate_py_expressions(self,objects)
-
-        # Evaluate remaining bash commands of the form $(...)
-        evaluate_bash_commands(self)
 
         # Check props are valid
         expect (self.mach_file is None or pathlib.Path(self.mach_file).expanduser().exists(),

--- a/cacts/project.py
+++ b/cacts/project.py
@@ -4,7 +4,7 @@ that CACTS will use at runtime
 """
 from dataclasses import dataclass, field
 from typing import Dict, Optional
-from .utils import expect, evaluate_bash_commands
+from .utils import expect
 
 ###############################################################################
 @dataclass
@@ -71,7 +71,3 @@ class Project:
         self.cmake_settings.setdefault('baselines_only',{})
 
         self.cdash = project_specs.get('cdash',{})
-
-    def __post_init__  (self):
-        # Evaluate bash commands of the form $(...)
-        evaluate_bash_commands(self)

--- a/cacts/utils.py
+++ b/cacts/utils.py
@@ -226,7 +226,22 @@ def evaluate_py_expressions(tgt_obj, src_obj_dict):
         expression = tgt_obj[beg+2:end]
 
         restricted_globals = {
-            "__builtins__": None  # Disable all built-in functions
+            "__builtins__": {
+                "str": str,
+                "int": int,
+                "float": float,
+                "list": list,
+                "set": set,
+                "tuple": tuple,
+                "dict": dict,
+                "enumerate": enumerate,
+                "len": len,
+                "sum": sum,
+                "abs": abs,
+                "max": max,
+                "min": min,
+                "round": round
+            }
         }
         restricted_globals.update(src_obj_dict)
         result = eval(expression,restricted_globals)

--- a/cacts/utils.py
+++ b/cacts/utils.py
@@ -258,41 +258,8 @@ def safe_expression(expression):
     for pattern in dangerous_patterns:
         if re.search(pattern, expression):
             return False  # Unsafe expression
-    
+
     return True  # Safe expression
-
-###############################################################################
-def evaluate_bash_commands(tgt_obj,env_setup=None):
-###############################################################################
-
-    # Only user-defined types have the __dict__ attribute
-    if hasattr(tgt_obj,'__dict__'):
-        for name,val in vars(tgt_obj).items():
-            setattr(tgt_obj,name,evaluate_bash_commands(val,env_setup))
-
-    elif isinstance(tgt_obj,dict):
-        for name,val in tgt_obj.items():
-            tgt_obj[name] = evaluate_bash_commands(val,env_setup)
-
-    elif isinstance(tgt_obj,list):
-        for i,val in enumerate(tgt_obj):
-            tgt_obj[i] = evaluate_bash_commands(val,env_setup)
-
-    elif isinstance(tgt_obj,str):
-        pattern = r'\$\((.*?)\)'
-
-        matches = re.findall(pattern,tgt_obj)
-        for cmd in matches:
-            stat,out,err = run_cmd(cmd,env_setup=env_setup)
-            expect (stat==0,
-                    "Could not evaluate the command.\n"
-                    f"  - original string: {tgt_obj}\n"
-                    f"  - command: {cmd}\n"
-                    f"  - error: {err}\n")
-
-            tgt_obj = tgt_obj.replace(f"$({cmd})",out)
-
-    return tgt_obj
 
 ###############################################################################
 def str_to_bool(s, var_name):


### PR DESCRIPTION
The main reason for this was to have stuff like 

```
env_setup:
  - 'module load netcdf'
  - 'export NC_ROOT=$(nc-config --prefix)'
```
in the config file, but it would not work, as the bash cmd expansion would happen _before_ any of the commands in the list is executed (hence leaving NC_ROOT empty in the env).

Considering also the potential security risks, I decided to remove the feature.

Note: the similar utility `evaluate_py_expression` is a bit safer, as we do check that dangerous strings are not present (e.g., the import string).