### PR TITLE
Use /tmp as default work dir rather than a current folder subdir

### DIFF
--- a/cacts/cacts.py
+++ b/cacts/cacts.py
@@ -61,8 +61,6 @@ class Driver:
         self._generate      = generate
         self._baselines_dir = baseline_dir
         self._cmake_args    = cmake_args
-        work_dir_str = work_dir or os.getcwd()+"/ctest-build"
-        self._work_dir      = Path(work_dir_str).expanduser().absolute()
         self._verbose       = verbose
         self._config_only   = config_only
         self._build_only    = build_only
@@ -74,9 +72,6 @@ class Driver:
         self._machine       = None
         self._builds        = []
         self._config_file   = Path(config_file or self._root_dir / "cacts.yaml")
-
-        # Ensure work dir exists
-        self._work_dir.mkdir(parents=True,exist_ok=True)
 
         ###################################
         #  Parse the project config file  #
@@ -93,6 +88,14 @@ class Driver:
         self._machine = parse_machine(self._config_file,self._project,machine_name)
         self._builds  = parse_builds(self._config_file,self._project,
                                      self._machine,self._generate,build_types)
+
+        ###################################
+        #     Ensure work dir exists      #
+        ###################################
+
+        work_dir_str = work_dir if work_dir else self._machine.work_dir
+        self._work_dir = Path(work_dir_str).expanduser().absolute()
+        self._work_dir.mkdir(parents=True,exist_ok=True)
 
         ###################################
         #          Sanity Checks          #

--- a/cacts/machine.py
+++ b/cacts/machine.py
@@ -6,6 +6,7 @@ for a testing machine to be used by CACTS
 import pathlib
 import socket
 import re
+import os
 
 from .utils import expect, get_available_cpu_count, evaluate_py_expressions
 
@@ -57,6 +58,7 @@ class Machine: # pylint: disable=too-many-instance-attributes
         self.baselines_dir  = None
         self.valg_supp_file = None
         self.inherits       = None
+        self.work_dir       = os.getcwd() + "/ctest-build"
 
         # Set parameter, first using the 'default' machine (if any), then this machine's settings
         # Note: if this machine inherits from M2, M2's settings will be parsed first


### PR DESCRIPTION
We may not have write permissions in cwd, but /tmp should be writable by all. The user can still customize it via env var, by setting TMPDIR, or use the -w flag, if the default system-wide temp folder is not desirable.

Edit: using $(pwd)/ctest-build in a git repo also causes git to see a dirty tree (and one may accidentally commit those files). In EAMxx, I do have `components/eamxx/ctest-build` added to `.git/info/exclude`, but it seems silly to force the user to take care of this, when the os already offers /tmp for this kind of stuff.