### PR TITLE
Add projects config for ctest error exception strings

### DIFF
--- a/cacts/cacts.py
+++ b/cacts/cacts.py
@@ -514,6 +514,20 @@ class Driver:
         text += '# Start ctest session\n'
         text += 'ctest_start(Experimental)\n\n'
 
+        if self._project.ctest_error_exceptions:
+            text += '# Generate and load custom error exceptions dynamically\n'
+            text += 'file(WRITE "${CTEST_BINARY_DIRECTORY}/CTestCustom.cmake" "\n'
+            text += '  list(APPEND CTEST_CUSTOM_ERROR_EXCEPTION\n'
+
+            for exc in self._project.ctest_error_exceptions:
+                # We need to escape inner quotes and backslashes so they format perfectly in CMake
+                safe_exc = exc.replace('\\', '\\\\').replace('"', '\\"')
+                text += f'    \\"{safe_exc}\\"\n'
+
+            text += '  )\n'
+            text += '")\n'
+            text += 'ctest_read_custom_files("${CTEST_BINARY_DIRECTORY}")\n\n'
+
         text += '# Configure phase\n'
         text += 'separate_arguments(OPTIONS_LIST UNIX_COMMAND "${CMAKE_COMMAND}")\n'
         text += 'ctest_configure(OPTIONS "${OPTIONS_LIST}" RETURN_VALUE CONFIG_ERROR_CODE)\n'

--- a/cacts/project.py
+++ b/cacts/project.py
@@ -8,7 +8,7 @@ from .utils import expect
 
 ###############################################################################
 @dataclass
-class Project:
+class Project: # pylint: disable=too-many-instance-attributes
 ###############################################################################
     """
     An object storing config data for a cmake
@@ -18,6 +18,7 @@ class Project:
     baselines_gen_label: Optional[str] = None
     baselines_cmp_label: Optional[str] = None
     baselines_summary_file: Optional[str] = None
+    ctest_error_exceptions: list = field(default_factory=list)
     cdash: Dict[str, any] = field(default_factory=dict)
 
     # To check inside init
@@ -26,6 +27,7 @@ class Project:
             'baseline_gen_label',
             'baseline_cmp_label',
             'baseline_summary_file',
+            'ctest_error_exceptions',
             'cmake_settings',
             'cdash'
     }
@@ -58,6 +60,9 @@ class Project:
         # CACTS to ensure that ALL baselines tests complete sucessfully before copying
         # any file to the baselines directory
         self.baselines_summary_file = project_specs.get('baseline_summary_file',None)
+
+        # Allow projects to specify strings that ctest should ignore when scanning logs for errors
+        self.ctest_error_exceptions = project_specs.get('ctest_error_exceptions', [])
 
         # Allow to use a project cmake var that can turn on/off baseline-related code/tests.
         # Can help to limit build time

--- a/cacts/version.py
+++ b/cacts/version.py
@@ -4,4 +4,4 @@ NOTE: we put it here, rather than in __init__.py, so we can
 avoid pylint cyclic imports errors
 """
 
-__version__ = "0.2.4"
+__version__ = "0.3.0"


### PR DESCRIPTION
Allows a project to help ctest, which sometimes trips because of certain strings in the build log.

---

When using cacts in EKAT, with oneapi compiler I found that the source code line

```
struct format_handler : error_handler {
```
(which appeared in a compiler warning message) was parsed by CTest as an actual error. This is likely because of this regex in the ctest source code

```
  "([^ :]+) : (error|fatal error|catastrophic error)",
```
which matches the line above.

I confirmed that with this modification, I can successfully test ekat with cacts.