### PR TITLE
Fix handling of verbose flags for ctest

### DIFF
--- a/cacts/cacts.py
+++ b/cacts/cacts.py
@@ -462,7 +462,7 @@ class Driver:
         """
 
         ctest_cmd = "ctest"
-        ctest_cmd += " -VV" if self._verbose else " --output-on-failure"
+        ctest_cmd += " -VV" if self._verbose else " -V --output-on-failure"
         ctest_cmd += f" -S {self._work_dir / build.longname / 'ctest_script.cmake'}"
 
         ctest_cmd += f' -DCMAKE_COMMAND="{cmake_config}"'
@@ -675,7 +675,7 @@ OR
         help="Launch the different build types stacks in parallel")
 
     parser.add_argument("-v", "--verbose", action="store_true",
-        help="Print output of config/build/test phases as they would be printed by a manual run.")
+        help="Print tests output as they run (even if they pass).")
 
     parser.add_argument("--version", action="version", version=f"%(prog)s {version}",
         help="Show the version number and exit")

--- a/cacts/version.py
+++ b/cacts/version.py
@@ -4,4 +4,4 @@ NOTE: we put it here, rather than in __init__.py, so we can
 avoid pylint cyclic imports errors
 """
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"


### PR DESCRIPTION
Add `-V --output-on-failure` by default, and add `-VV`if the user calls `cacts` with the `-v` flag.

---

This allows to print in real time the tests as they run, so the user can tell if CTest is making any progress in the test phase or if it's stuck. Also, when using in CI, this allows to actually see the output of failed tests, without having to download artifacts. That's b/c ctest will NOT print tests output (even the failures) unless -V (or -VV) is added, when running in dashboard mode.